### PR TITLE
Update hydrojet option visibility logic

### DIFF
--- a/Code/data/automation.html
+++ b/Code/data/automation.html
@@ -255,11 +255,8 @@
             // Hide Hydrojet command if hardware has no jets
             const select = document.getElementById("commands");
             const hydroOption = select.querySelector('option[value="11"]');
-            if (!json.HASJETS) {
-              if (hydroOption) {
-                select.removeChild(hydroOption); 
-              }
-            }
+            if (hydroOption && !json.HASJETS)
+              hydroOption.remove()
           }
         };
 

--- a/Code/data/automation.html
+++ b/Code/data/automation.html
@@ -253,11 +253,13 @@
           if (this.readyState == 4 && this.status == 200) {
             var json = JSON.parse(req.responseText);
             // Hide Hydrojet command if hardware has no jets
-            const hydroOption = document.querySelector(
-              "#commands option[value='11']",
-            );
-            if (hydroOption)
-              hydroOption.style.display = json.HASJETS ? "" : "none";
+            const select = document.getElementById("commands");
+            const hydroOption = select.querySelector('option[value="11"]');
+            if (!json.HASJETS) {
+              if (hydroOption) {
+                select.removeChild(hydroOption); 
+              }
+            }
           }
         };
 


### PR DESCRIPTION
Remove hydrojet command option if hardware has no Hydrojet. Works with Safari, Edge and Chrome.
Had to be tested with Hydrojet device.

Entfernt Hydrojet Option bei den Automationen, wenn es die Hardware nicht hergibt. Funktioniert mit Safari (hat es vorher nicht), Edge und Chrome.
Muss mit einem Hydrojet Gerät getestet werden (habe leider nur ein Airjet und da ist die Option raus.
