### PR TITLE
feat(e2e): add Playwright tests for real WifiWhirl modules 

### DIFF
--- a/Code/e2e/Dockerfile
+++ b/Code/e2e/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/playwright:v1.61.0-noble
+
+WORKDIR /tests
+
+COPY package.json ./
+RUN npm install
+
+COPY playwright.config.js ./
+COPY tests ./tests
+
+ENV CI=1
+
+CMD ["npm", "test"]

--- a/Code/e2e/README.md
+++ b/Code/e2e/README.md
@@ -1,0 +1,154 @@
+# WifiWhirl real-module E2E tests
+
+These Playwright tests run against a real WifiWhirl module on your network.
+They are intentionally read-only or UI-only and do not click pump, heater, or
+Airjet controls. This is important when the pump has no pool connected.
+
+## Requirements
+
+- Docker
+- A reachable WifiWhirl module IP address
+- The computer running Docker must be on the same network as the module
+
+## Run with Docker
+
+Build the test image from this folder:
+
+```sh
+cd e2e
+docker build -t wifiwhirl-e2e .
+```
+
+Rebuild this image after changing the tests. Docker runs the files copied into
+the image at build time, so old failure line numbers usually mean an old image
+is still being used.
+
+Run the tests by passing the module address before execution:
+
+```sh
+docker run --rm -e MODULE_URL=http://192.168.178.42 wifiwhirl-e2e
+```
+
+`MODULE_URL` may include or omit `http://`.
+
+```sh
+docker run --rm -e MODULE_URL=192.168.178.42 wifiwhirl-e2e
+```
+
+The suite is configured for the ESP8266's limited single-core CPU:
+
+- one Playwright worker only
+- high navigation/action/assertion timeouts
+- a pause after every mutating request
+- retries for transient read requests such as short `socket hang up` resets
+
+The default post-write pause is 1500 ms. Increase it if your module feels busy:
+
+```sh
+docker run --rm \
+  -e MODULE_URL=http://192.168.178.42 \
+  -e ESP_SETTLE_MS=3000 \
+  wifiwhirl-e2e
+```
+
+Target temperature, display brightness, and lock changes need more time because
+they go through the pump/display command path. The tests wait 10000 ms after
+each of these commands before checking the result. Increase this separately if
+your module or pump reacts more slowly:
+
+```sh
+docker run --rm \
+  -e MODULE_URL=http://192.168.178.42 \
+  -e ESP_HARDWARE_SETTLE_MS=15000 \
+  wifiwhirl-e2e
+```
+
+Those hardware-facing checks are skipped if the module accepts the command but
+the attached pump/display does not report the changed state after the extended
+wait. That keeps the suite useful on real modules where a specific pump/display
+command is unavailable, delayed, or refused, while still restoring values that
+were actually changed.
+
+Read requests are retried 3 times by default. Increase this if the module drops
+connections while busy:
+
+```sh
+docker run --rm \
+  -e MODULE_URL=http://192.168.178.42 \
+  -e ESP_REQUEST_RETRIES=5 \
+  wifiwhirl-e2e
+```
+
+## Run locally without Docker
+
+```sh
+cd e2e
+npm install
+MODULE_URL=http://192.168.178.42 npm test
+```
+
+## Reports and artifacts
+
+On failure, Playwright writes traces, screenshots, videos, and HTML reports.
+These files are ignored by `e2e/.gitignore`.
+
+To keep artifacts from a Docker run, mount a local directory:
+
+```sh
+docker run --rm \
+  -e MODULE_URL=http://192.168.178.42 \
+  -v "$PWD/test-results:/tests/test-results" \
+  -v "$PWD/playwright-report:/tests/playwright-report" \
+  wifiwhirl-e2e
+```
+
+## Test coverage
+
+The suite currently lives in `tests/read-only.spec.js`.
+
+| Test name | What it checks | Writes to module |
+| --- | --- | --- |
+| `read-only backend endpoints respond with expected shapes` | Calls `/gettemps/`, `/getconfig/`, `/getsmartschedule/`, and `/getcommands/`; verifies expected JSON fields and basic types. | No |
+| `read-only configuration endpoints expose valid JSON` | Calls `/getwebconfig/`, `/getmqtt/`, `/getwifi/`, and `/gethardware/`; verifies representative config keys exist. | No |
+| `temperature endpoint supports field filtering` | Calls `/gettemps/?currentC&targetC`; verifies only requested temperature fields are returned. | No |
+| `polling fallback returns states, times, and other info` | Calls `/getpolldata/`; verifies it returns `[STATES, TIMES, OTHER]` with representative fields such as target temperature, brightness, uptime, firmware, and IP. | No |
+| `webhook status endpoints expose safe read-only state` | Calls webhook read endpoints `/getstates/` and `/gettemps/`; verifies state and temperature JSON fields and types. | No |
+| `webhook endpoints enforce GET and reject invalid hook payloads` | Verifies `/hook/`, `/getstates/`, and `/gettemps/` reject POST with `405`; verifies `/hook/` rejects missing or invalid `send` JSON with `400`. | No saved state should change |
+| `webhook can schedule and clean up a safe future text command` | Calls `/hook/?send=...` with a future `PRINTTEXT` command, verifies it appears in the queue, then deletes it. Skips if the queue is full. | Yes, one temporary future text command |
+| `sendcommand fallback can schedule and clean up a safe future text command` | Calls `/sendcommand/` with a future `PRINTTEXT` command, verifies it appears in the queue, then deletes it. Skips if the queue is full. | Yes, one temporary future text command |
+| `command queue can download and rejects invalid restore payload` | Downloads queue JSON through `/cmdq_file/`; posts invalid JSON to upload and expects a clean `400` error. | Only sends invalid upload; no saved state should change |
+| `command queue restore rejects malformed structures` | Uploads invalid queue JSON variants: missing `LEN`, array length mismatch, more than 20 commands, and invalid `TXT` shape. Verifies each is rejected. | No saved state should change |
+| `smart schedule API rejects invalid updates without creating schedules` | Posts invalid Smart Schedule payloads: past target time, invalid target temperature, and missing `KEEPON` update. Verifies clean rejection. | No saved state should change |
+| `target temperature and brightness can be changed and restored` | Uses `/sendcommand/` to set a temporary target temperature and display brightness, waits for the real pump/display path, verifies via `/getpolldata/`, then restores values that changed. Skips if the queue is full or the module accepts the command but does not report the changed state. | Yes, temporary target/brightness changes |
+| `lock can be toggled and restored` | Uses `/sendcommand/` to toggle lock, waits for the real pump/display path, verifies via `/getstates/`, then toggles back to the original state. Skips if the queue is full or the module accepts the command but does not report the changed state. | Yes, temporary lock toggle |
+| `safe future text command can be added, edited, and deleted` | Adds a future `PRINTTEXT` command, verifies it appears, edits it, verifies the edit, deletes it, and verifies cleanup. Skips if the queue is full. | Yes, one temporary future text command |
+| `dashboard and navigation pages load without unsafe control actions` | Opens dashboard, config, automation, Smart Schedule, web, WiFi, hardware, and info pages; verifies page shell/header. | No |
+| `smart schedule exposes cost estimate and editable heater target behavior` | Checks Smart Schedule cost UI and heater-behavior select/options exist. | No |
+| `smart schedule client-side validation blocks unsafe submissions` | Calls `setSchedule()` with missing date, invalid temp, and past date; verifies browser validation alerts prevent submission. | No |
+| `automation UI uses the safe Bedientasten sperren wording` | Verifies command option `26` label and form labels read `Bedientasten sperren`, `sperren`, and `entsperren`. | No |
+| `automation form serializes safe commands without hardware command IDs` | Checks client-side JSON for command `26` and `PRINTTEXT`; does not send it to the module. | No |
+| `dark mode toggle persists locally without module writes` | Toggles dark mode in browser localStorage, reloads, verifies persistence, then turns it off. | No |
+| `web config localStorage controls dashboard section visibility without module writes` | Intercepts web-config API calls in the browser, saves UI section visibility to localStorage, and verifies dashboard section hiding without writing real module config. | No |
+| `mobile navigation menu opens and closes` | Uses a mobile viewport and verifies the hamburger nav toggles responsive state. | No |
+| `core pages do not overflow on desktop or mobile viewports` | Opens core pages on mobile and desktop viewport sizes; verifies no horizontal document overflow. | No |
+| `static assets and manifest are served` | Fetches `/manifest.json`, `/main.css`, `/function.js`, and `/logo.png`; verifies they are served. | No |
+| `system info assets and prometheus metrics are served` | Fetches `/info.html`, favicon, fonts, melodies, and `/metrics`; verifies successful responses and Prometheus metric text. | No |
+| `configuration pages use alternating section styling` | Opens config-related pages and verifies at least one `section.odd-section` exists. | No |
+
+## Safety scope
+
+The tests may:
+
+- read current module state and configuration
+- navigate UI pages
+- change browser-local state such as dark mode
+- create, edit, and delete one temporary future `PRINTTEXT` queue entry
+- temporarily change and restore target temperature, display brightness, and lock state
+
+The tests do not:
+
+- turn on/off the pump
+- turn on/off the heater
+- turn on/off Airjet or Hydrojet
+- restore or reset the automation queue
+- save configuration changes

--- a/Code/e2e/README.md
+++ b/Code/e2e/README.md
@@ -1,8 +1,16 @@
 # WifiWhirl real-module E2E tests
 
 These Playwright tests run against a real WifiWhirl module on your network.
-They are intentionally read-only or UI-only and do not click pump, heater, or
-Airjet controls. This is important when the pump has no pool connected.
+Most are read-only or UI-only. A few perform safe, temporary changes that are
+automatically restored afterwards (e.g. target temperature, display
+brightness, lock state, a queued command, the Smart Schedule, timezone, and
+PLZ). Creating a Smart Schedule can make the module start the pump and
+heater on its own as part of normal device behavior. None of the tests
+click Airjet or Hydrojet controls. This is important when the pump has no
+pool connected. Running the pump/heater dry without a [descaler
+cartridge](https://www.bestwaystore.de/lay-z-spa-entkalker-fuer-alle-lay-z-spa-pumpeneinheiten/60343-26)
+in the bypass can trigger an E02 error. Insert one to let the pump unit run
+without an actual pool connected.
 
 ## Requirements
 
@@ -15,13 +23,11 @@ Airjet controls. This is important when the pump has no pool connected.
 Build the test image from this folder:
 
 ```sh
-cd e2e
 docker build -t wifiwhirl-e2e .
 ```
 
 Rebuild this image after changing the tests. Docker runs the files copied into
-the image at build time, so old failure line numbers usually mean an old image
-is still being used.
+the image at build time.
 
 Run the tests by passing the module address before execution:
 
@@ -63,12 +69,6 @@ docker run --rm \
   wifiwhirl-e2e
 ```
 
-Those hardware-facing checks are skipped if the module accepts the command but
-the attached pump/display does not report the changed state after the extended
-wait. That keeps the suite useful on real modules where a specific pump/display
-command is unavailable, delayed, or refused, while still restoring values that
-were actually changed.
-
 Read requests are retried 3 times by default. Increase this if the module drops
 connections while busy:
 
@@ -106,34 +106,38 @@ docker run --rm \
 
 The suite currently lives in `tests/read-only.spec.js`.
 
-| Test name | What it checks | Writes to module |
-| --- | --- | --- |
-| `read-only backend endpoints respond with expected shapes` | Calls `/gettemps/`, `/getconfig/`, `/getsmartschedule/`, and `/getcommands/`; verifies expected JSON fields and basic types. | No |
-| `read-only configuration endpoints expose valid JSON` | Calls `/getwebconfig/`, `/getmqtt/`, `/getwifi/`, and `/gethardware/`; verifies representative config keys exist. | No |
-| `temperature endpoint supports field filtering` | Calls `/gettemps/?currentC&targetC`; verifies only requested temperature fields are returned. | No |
-| `polling fallback returns states, times, and other info` | Calls `/getpolldata/`; verifies it returns `[STATES, TIMES, OTHER]` with representative fields such as target temperature, brightness, uptime, firmware, and IP. | No |
-| `webhook status endpoints expose safe read-only state` | Calls webhook read endpoints `/getstates/` and `/gettemps/`; verifies state and temperature JSON fields and types. | No |
-| `webhook endpoints enforce GET and reject invalid hook payloads` | Verifies `/hook/`, `/getstates/`, and `/gettemps/` reject POST with `405`; verifies `/hook/` rejects missing or invalid `send` JSON with `400`. | No saved state should change |
-| `webhook can schedule and clean up a safe future text command` | Calls `/hook/?send=...` with a future `PRINTTEXT` command, verifies it appears in the queue, then deletes it. Skips if the queue is full. | Yes, one temporary future text command |
-| `sendcommand fallback can schedule and clean up a safe future text command` | Calls `/sendcommand/` with a future `PRINTTEXT` command, verifies it appears in the queue, then deletes it. Skips if the queue is full. | Yes, one temporary future text command |
-| `command queue can download and rejects invalid restore payload` | Downloads queue JSON through `/cmdq_file/`; posts invalid JSON to upload and expects a clean `400` error. | Only sends invalid upload; no saved state should change |
-| `command queue restore rejects malformed structures` | Uploads invalid queue JSON variants: missing `LEN`, array length mismatch, more than 20 commands, and invalid `TXT` shape. Verifies each is rejected. | No saved state should change |
-| `smart schedule API rejects invalid updates without creating schedules` | Posts invalid Smart Schedule payloads: past target time, invalid target temperature, and missing `KEEPON` update. Verifies clean rejection. | No saved state should change |
-| `target temperature and brightness can be changed and restored` | Uses `/sendcommand/` to set a temporary target temperature and display brightness, waits for the real pump/display path, verifies via `/getpolldata/`, then restores values that changed. Skips if the queue is full or the module accepts the command but does not report the changed state. | Yes, temporary target/brightness changes |
-| `lock can be toggled and restored` | Uses `/sendcommand/` to toggle lock, waits for the real pump/display path, verifies via `/getstates/`, then toggles back to the original state. Skips if the queue is full or the module accepts the command but does not report the changed state. | Yes, temporary lock toggle |
-| `safe future text command can be added, edited, and deleted` | Adds a future `PRINTTEXT` command, verifies it appears, edits it, verifies the edit, deletes it, and verifies cleanup. Skips if the queue is full. | Yes, one temporary future text command |
-| `dashboard and navigation pages load without unsafe control actions` | Opens dashboard, config, automation, Smart Schedule, web, WiFi, hardware, and info pages; verifies page shell/header. | No |
-| `smart schedule exposes cost estimate and editable heater target behavior` | Checks Smart Schedule cost UI and heater-behavior select/options exist. | No |
-| `smart schedule client-side validation blocks unsafe submissions` | Calls `setSchedule()` with missing date, invalid temp, and past date; verifies browser validation alerts prevent submission. | No |
-| `automation UI uses the safe Bedientasten sperren wording` | Verifies command option `26` label and form labels read `Bedientasten sperren`, `sperren`, and `entsperren`. | No |
-| `automation form serializes safe commands without hardware command IDs` | Checks client-side JSON for command `26` and `PRINTTEXT`; does not send it to the module. | No |
-| `dark mode toggle persists locally without module writes` | Toggles dark mode in browser localStorage, reloads, verifies persistence, then turns it off. | No |
-| `web config localStorage controls dashboard section visibility without module writes` | Intercepts web-config API calls in the browser, saves UI section visibility to localStorage, and verifies dashboard section hiding without writing real module config. | No |
-| `mobile navigation menu opens and closes` | Uses a mobile viewport and verifies the hamburger nav toggles responsive state. | No |
-| `core pages do not overflow on desktop or mobile viewports` | Opens core pages on mobile and desktop viewport sizes; verifies no horizontal document overflow. | No |
-| `static assets and manifest are served` | Fetches `/manifest.json`, `/main.css`, `/function.js`, and `/logo.png`; verifies they are served. | No |
-| `system info assets and prometheus metrics are served` | Fetches `/info.html`, favicon, fonts, melodies, and `/metrics`; verifies successful responses and Prometheus metric text. | No |
-| `configuration pages use alternating section styling` | Opens config-related pages and verifies at least one `section.odd-section` exists. | No |
+| # | Test name | What it checks | Writes to module |
+| --- | --- | --- | --- |
+| 1 | `read-only backend endpoints respond with expected shapes` | Calls `/gettemps/`, `/getconfig/`, `/getsmartschedule/`, and `/getcommands/`; verifies expected JSON fields and basic types. | No |
+| 2 | `read-only configuration endpoints expose valid JSON` | Calls `/getwebconfig/`, `/getmqtt/`, `/getwifi/`, and `/gethardware/`; verifies representative config keys exist. | No |
+| 3 | `temperature endpoint supports field filtering` | Calls `/gettemps/?currentC&targetC`; verifies only requested temperature fields are returned. | No |
+| 4 | `polling fallback returns states, times, and other info` | Calls `/getpolldata/`; verifies it returns `[STATES, TIMES, OTHER]` with representative fields such as target temperature, brightness, uptime, firmware, and IP. | No |
+| 5 | `webhook status endpoints expose safe read-only state` | Calls webhook read endpoints `/getstates/` and `/gettemps/`; verifies state and temperature JSON fields and types. | No |
+| 6 | `info endpoint reports ESP diagnostics` | Calls `/info/`; verifies the response contains `Stack size:` and `Free Heap:`. | No |
+| 7 | `static assets and manifest are served` | Fetches `/manifest.json`, `/main.css`, `/function.js`, and `/logo.png`; verifies they are served. | No |
+| 8 | `system info assets and prometheus metrics are served` | Fetches `/info.html`, favicon, fonts, melodies, and `/metrics`; verifies successful responses and Prometheus metric text. | No |
+| 9 | `webhook endpoints enforce GET and reject invalid hook payloads` | Verifies `/hook/`, `/getstates/`, and `/gettemps/` reject POST with `405`; verifies `/hook/` rejects missing or invalid `send` JSON with `400`. | No saved state should change |
+| 10 | `webhook can schedule and clean up a safe future text command` | Calls `/hook/?send=...` with a future `PRINTTEXT` command, verifies it appears in the queue, then deletes it. Skips if the queue is full. | Yes, one temporary future text command |
+| 11 | `sendcommand fallback can schedule and clean up a safe future text command` | Calls `/sendcommand/` with a future `PRINTTEXT` command, verifies it appears in the queue, then deletes it. Skips if the queue is full. | Yes, one temporary future text command |
+| 12 | `safe future text command can be added, edited, and deleted` | Adds a future `PRINTTEXT` command, verifies it appears, edits it, verifies the edit, deletes it, and verifies cleanup. Skips if the queue is full. | Yes, one temporary future text command |
+| 13 | `command queue can download and rejects invalid restore payload` | Downloads queue JSON through `/cmdq_file/`; posts invalid JSON to upload and expects a clean `400` error. | Only sends invalid upload; no saved state should change |
+| 14 | `command queue restore rejects malformed structures` | Uploads invalid queue JSON variants: missing `LEN`, array length mismatch, more than 20 commands, and invalid `TXT` shape. Verifies each is rejected. | No saved state should change |
+| 15 | `smart schedule API rejects invalid updates without creating schedules` | Posts invalid Smart Schedule payloads: past target time, invalid target temperature, and missing `KEEPON` update. Verifies clean rejection. | No saved state should change |
+| 16 | `smart schedule can be created, verified, and cancelled` | Cancels any pre-existing active schedule, creates a new Smart Schedule via `/setsmartschedule/`, verifies its fields via `/getsmartschedule/`, then cancels it via `/cancelsmartschedule/` and verifies it is no longer active. | Yes, temporary Smart Schedule create/cancel |
+| 17 | `smart schedule exposes cost estimate and editable heater target behavior` | Checks Smart Schedule cost UI and heater-behavior select/options exist. | No |
+| 18 | `smart schedule client-side validation blocks unsafe submissions` | Calls `setSchedule()` with missing date, invalid temp, and past date; verifies browser validation alerts prevent submission. | No |
+| 19 | `target temperature and brightness can be changed and restored` | Uses `/sendcommand/` to set a temporary target temperature and display brightness, waits for the real pump/display path, verifies via `/getpolldata/`, then restores values that changed. Skips if the queue is full or the module accepts the command but does not report the changed state. | Yes, temporary target/brightness changes |
+| 20 | `lock can be toggled and restored` | Uses `/sendcommand/` to toggle lock, waits for the real pump/display path, verifies via `/getstates/`, then toggles back to the original state. Skips if the queue is full or the module accepts the command but does not report the changed state. | Yes, temporary lock toggle |
+| 21 | `configurable timezone can be changed and restored` | Changes `TIMEZONE`/`TIMEZONE_NAME` via `/setconfig/`, verifies the change via `/getconfig/`, then restores the original values. | Yes, temporary timezone change |
+| 22 | `weather endpoint returns the city name for German and Austrian PLZ` | Temporarily sets `PLZ` via `/setconfig/` to a German (`48268`) and an Austrian (`1010`) postal code, calls `/getweather/`, and verifies a non-empty city name is returned for each; restores the original `PLZ`. | Yes, temporary `PLZ` change |
+| 23 | `dashboard and navigation pages load without unsafe control actions` | Opens dashboard, config, automation, Smart Schedule, web, WiFi, hardware, and info pages; verifies page shell/header. | No |
+| 24 | `configuration pages use alternating section styling` | Opens config-related pages and verifies at least one `section.odd-section` exists. | No |
+| 25 | `automation UI uses the safe Bedientasten sperren wording` | Verifies command option `26` label and form labels read `Bedientasten sperren`, `sperren`, and `entsperren`. | No |
+| 26 | `automation form serializes safe commands without hardware command IDs` | Checks client-side JSON for command `26` and `PRINTTEXT`; does not send it to the module. | No |
+| 27 | `dark mode toggle persists locally without module writes` | Toggles dark mode in browser localStorage, reloads, verifies persistence, then turns it off. | No |
+| 28 | `web config localStorage controls dashboard section visibility without module writes` | Intercepts web-config API calls in the browser, saves UI section visibility to localStorage, and verifies dashboard section hiding without writing real module config. | No |
+| 29 | `mobile navigation menu opens and closes` | Uses a mobile viewport and verifies the hamburger nav toggles responsive state. | No |
+| 30 | `core pages do not overflow on desktop or mobile viewports` | Opens core pages on mobile and desktop viewport sizes; verifies no horizontal document overflow. | No |
 
 ## Safety scope
 
@@ -144,11 +148,13 @@ The tests may:
 - change browser-local state such as dark mode
 - create, edit, and delete one temporary future `PRINTTEXT` queue entry
 - temporarily change and restore target temperature, display brightness, and lock state
+- temporarily create and cancel one Smart Schedule, which can make the module
+  start the pump and heater on its own as part of normal device behavior
+- temporarily change and restore `PLZ` and `TIMEZONE`/`TIMEZONE_NAME` settings
 
 The tests do not:
 
-- turn on/off the pump
-- turn on/off the heater
+- directly turn on/off the pump or heater themselves
 - turn on/off Airjet or Hydrojet
 - restore or reset the automation queue
 - save configuration changes

--- a/Code/e2e/package.json
+++ b/Code/e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "wifiwhirl-real-module-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Playwright E2E tests for a real WifiWhirl module.",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.54.0"
+  }
+}

--- a/Code/e2e/playwright.config.js
+++ b/Code/e2e/playwright.config.js
@@ -1,0 +1,49 @@
+// @ts-check
+const { defineConfig, devices } = require("@playwright/test");
+
+function getModuleUrl() {
+  const rawUrl = process.env.MODULE_URL || process.env.WIFIWHIRL_URL;
+  if (!rawUrl) {
+    throw new Error(
+      "Set MODULE_URL before running tests, for example: MODULE_URL=http://192.168.178.42 npm test",
+    );
+  }
+
+  const withProtocol = /^https?:\/\//i.test(rawUrl)
+    ? rawUrl
+    : `http://${rawUrl}`;
+
+  const url = new URL(withProtocol);
+  url.pathname = url.pathname.replace(/\/+$/, "");
+  url.search = "";
+  url.hash = "";
+  return url.toString().replace(/\/$/, "");
+}
+
+const moduleUrl = getModuleUrl();
+
+module.exports = defineConfig({
+  testDir: "./tests",
+  fullyParallel: false,
+  workers: 1,
+  timeout: 180 * 1000,
+  expect: {
+    timeout: 30 * 1000,
+  },
+  retries: process.env.CI ? 1 : 0,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: moduleUrl,
+    actionTimeout: 30 * 1000,
+    navigationTimeout: 60 * 1000,
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/Code/e2e/tests/read-only.spec.js
+++ b/Code/e2e/tests/read-only.spec.js
@@ -1,0 +1,909 @@
+const { test, expect } = require("@playwright/test");
+
+const ESP_SETTLE_MS = Number(process.env.ESP_SETTLE_MS || 1500);
+const ESP_HARDWARE_SETTLE_MS = Number(process.env.ESP_HARDWARE_SETTLE_MS || 10000);
+const ESP_REQUEST_RETRIES = Number(process.env.ESP_REQUEST_RETRIES || 3);
+
+async function wait(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function postJson(request, path, body = {}) {
+  const response = await request.post(path, { data: body });
+  expect(response.ok(), `${path} returned ${response.status()}`).toBeTruthy();
+  return response.json();
+}
+
+async function waitForEspToSettle() {
+  await wait(ESP_SETTLE_MS);
+}
+
+async function waitForHardwareCommandToApply() {
+  await wait(ESP_HARDWARE_SETTLE_MS);
+}
+
+function futureTimestamp(secondsFromNow = 7 * 24 * 60 * 60) {
+  return Math.floor(Date.now() / 1000) + secondsFromNow;
+}
+
+function findCommandIndex(queue, predicate) {
+  for (let i = 0; i < queue.LEN; i += 1) {
+    const item = {
+      cmd: queue.CMD?.[i],
+      value: queue.VALUE?.[i],
+      xtime: queue.XTIME?.[i],
+      interval: queue.INTERVAL?.[i],
+      text: queue.TXT?.[i] || "",
+    };
+
+    if (predicate(item)) {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+function webhookPath(payload) {
+  return `/hook/?send=${encodeURIComponent(JSON.stringify(payload))}`;
+}
+
+async function getJsonWithRetry(request, path) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= Math.max(ESP_REQUEST_RETRIES, 1); attempt += 1) {
+    try {
+      const response = await request.get(path, { timeout: 30 * 1000 });
+      if (!response.ok()) {
+        throw new Error(`${path} returned ${response.status()}`);
+      }
+      return await response.json();
+    } catch (error) {
+      lastError = error;
+      if (attempt < ESP_REQUEST_RETRIES) {
+        await waitForEspToSettle();
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+async function getPollData(request) {
+  return getJsonWithRetry(request, "/getpolldata/");
+}
+
+async function getPollStates(request) {
+  const data = await getPollData(request);
+  return data[0];
+}
+
+async function sendCommand(request, command) {
+  const payload = {
+    XTIME: 0,
+    INTERVAL: 0,
+    TXT: "",
+    ...command,
+  };
+  const response = await request.post("/sendcommand/", { data: payload });
+  if (response.status() === 409) {
+    test.skip(true, "Command queue is full on the target module.");
+  }
+  expect(response.ok(), `/sendcommand/ returned ${response.status()}`).toBeTruthy();
+  await waitForEspToSettle();
+  return response.text();
+}
+
+async function getWebhookStates(request) {
+  return getJsonWithRetry(request, "/getstates/");
+}
+
+async function waitForPolledValue(getter, expected, options = {}) {
+  const timeout = options.timeout || 90 * 1000;
+  const intervals = options.intervals || [3000, 5000, 7000];
+  const deadline = Date.now() + timeout;
+  let attempt = 0;
+  let lastValue;
+  let lastError;
+
+  while (Date.now() < deadline) {
+    try {
+      lastValue = await getter();
+      lastError = undefined;
+      if (Object.is(lastValue, expected)) {
+        return { matched: true, lastValue };
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await wait(intervals[Math.min(attempt, intervals.length - 1)]);
+    attempt += 1;
+  }
+
+  return { matched: false, lastValue, lastError };
+}
+
+async function expectPolledValue(getter, expected, message) {
+  const result = await waitForPolledValue(getter, expected);
+  const lastSeen = result.lastError
+    ? `last error: ${result.lastError.message}`
+    : `last value: ${JSON.stringify(result.lastValue)}`;
+  expect(result.matched, `${message}; ${lastSeen}`).toBeTruthy();
+}
+
+async function expectAlertFromEvaluate(page, callback, expectedText) {
+  const dialogPromise = page.waitForEvent("dialog");
+  const evaluatePromise = page.evaluate(callback);
+  const dialog = await dialogPromise;
+  expect(dialog.message()).toContain(expectedText);
+  await dialog.accept();
+  await evaluatePromise;
+}
+
+test.describe("WifiWhirl real module smoke tests", () => {
+  test("read-only backend endpoints respond with expected shapes", async ({ request }) => {
+    const statesResponse = await request.get("/gettemps/");
+    expect(
+      statesResponse.ok(),
+      `/gettemps/ returned ${statesResponse.status()}`,
+    ).toBeTruthy();
+    const temps = await statesResponse.json();
+    expect(temps).toEqual(
+      expect.objectContaining({
+        currentC: expect.any(Number),
+        targetC: expect.any(Number),
+        ambientC: expect.any(Number),
+        unit: expect.stringMatching(/^[CF]$/),
+      }),
+    );
+
+    const config = await postJson(request, "/getconfig/");
+    expect(config).toEqual(
+      expect.objectContaining({
+        PRICE: expect.any(Number),
+        POOLCAP: expect.any(Number),
+      }),
+    );
+
+    const schedule = await postJson(request, "/getsmartschedule/");
+    expect(schedule).toEqual(
+      expect.objectContaining({
+        CONTENT: "SMARTSCHEDULE",
+        ACTIVE: expect.any(Boolean),
+        KEEPON: expect.any(Boolean),
+        ESTIMATED_KWH: expect.any(Number),
+        ESTIMATED_COST: expect.any(Number),
+      }),
+    );
+
+    const queue = await postJson(request, "/getcommands/");
+    expect(queue).toEqual(
+      expect.objectContaining({
+        LEN: expect.any(Number),
+      }),
+    );
+    expect(queue.LEN).toBeGreaterThanOrEqual(0);
+  });
+
+  test("read-only configuration endpoints expose valid JSON", async ({ request }) => {
+    const endpoints = [
+      { path: "/getwebconfig/", keys: ["SST", "SSD", "UCS"] },
+      { path: "/getmqtt/", keys: ["enableMqtt", "mqttServer", "mqttPort"] },
+      { path: "/getwifi/", keys: ["enableAp", "enableWM", "wmApName"] },
+      { path: "/gethardware/", keys: ["cio", "dsp", "pcb"] },
+    ];
+
+    for (const endpoint of endpoints) {
+      const payload = await postJson(request, endpoint.path);
+      for (const key of endpoint.keys) {
+        expect(payload, `${endpoint.path} missing ${key}`).toHaveProperty(key);
+      }
+    }
+  });
+
+  test("temperature endpoint supports field filtering", async ({ request }) => {
+    const response = await request.get("/gettemps/?currentC&targetC");
+    expect(response.ok(), `/gettemps/ filter returned ${response.status()}`).toBeTruthy();
+
+    const payload = await response.json();
+    expect(payload).toEqual(
+      expect.objectContaining({
+        currentC: expect.any(Number),
+        targetC: expect.any(Number),
+      }),
+    );
+    expect(payload).not.toHaveProperty("ambientC");
+    expect(payload).not.toHaveProperty("unit");
+  });
+
+  test("polling fallback returns states, times, and other info", async ({ request }) => {
+    const payload = await getPollData(request);
+    expect(Array.isArray(payload)).toBe(true);
+    expect(payload).toHaveLength(3);
+    expect(payload[0]).toEqual(
+      expect.objectContaining({
+        CONTENT: "STATES",
+        TGT: expect.any(Number),
+        BRT: expect.any(Number),
+        LCK: expect.any(Number),
+      }),
+    );
+    expect(payload[1]).toEqual(
+      expect.objectContaining({
+        CONTENT: "TIMES",
+        UPTIME: expect.any(Number),
+      }),
+    );
+    expect(payload[2]).toEqual(
+      expect.objectContaining({
+        CONTENT: "OTHER",
+        FW: expect.any(String),
+        IP: expect.any(String),
+      }),
+    );
+  });
+
+  test("webhook status endpoints expose safe read-only state", async ({ request }) => {
+    const statesResponse = await request.get("/getstates/");
+    expect(
+      statesResponse.ok(),
+      `/getstates/ returned ${statesResponse.status()}`,
+    ).toBeTruthy();
+    const states = await statesResponse.json();
+    expect(states).toEqual(
+      expect.objectContaining({
+        pump: expect.any(Boolean),
+        heater: expect.any(Boolean),
+        bubbles: expect.any(Boolean),
+        jets: expect.any(Boolean),
+        power: expect.any(Boolean),
+        lock: expect.any(Boolean),
+      }),
+    );
+
+    const tempsResponse = await request.get("/gettemps/");
+    expect(
+      tempsResponse.ok(),
+      `/gettemps/ returned ${tempsResponse.status()}`,
+    ).toBeTruthy();
+    const temps = await tempsResponse.json();
+    expect(temps).toEqual(
+      expect.objectContaining({
+        currentC: expect.any(Number),
+        currentF: expect.any(Number),
+        targetC: expect.any(Number),
+        targetF: expect.any(Number),
+        ambientC: expect.any(Number),
+        ambientF: expect.any(Number),
+        unit: expect.stringMatching(/^[CF]$/),
+      }),
+    );
+  });
+
+  test("webhook endpoints enforce GET and reject invalid hook payloads", async ({ request }) => {
+    for (const path of ["/hook/", "/getstates/", "/gettemps/"]) {
+      const response = await request.post(path, { data: {} });
+      expect(response.status(), `${path} should reject POST`).toBe(405);
+      await expect(response.text()).resolves.toContain("Method not allowed");
+      await waitForEspToSettle();
+    }
+
+    const missingSend = await request.get("/hook/");
+    expect(missingSend.status()).toBe(400);
+    await expect(missingSend.text()).resolves.toContain("Error deserializing message");
+
+    const invalidJson = await request.get("/hook/?send=not-json");
+    expect(invalidJson.status()).toBe(400);
+    await expect(invalidJson.text()).resolves.toContain("Error deserializing message");
+    await waitForEspToSettle();
+  });
+
+  test("webhook can schedule and clean up a safe future text command", async ({ request }) => {
+    const uniqueText = `wh${Date.now().toString(36).slice(-8)}`;
+    let activeText = uniqueText;
+    const xtime = futureTimestamp(9 * 24 * 60 * 60);
+
+    const hookResponse = await request.get(
+      webhookPath({
+        CMD: 19,
+        VALUE: 1,
+        XTIME: xtime,
+        INTERVAL: 0,
+        TXT: uniqueText,
+      }),
+    );
+
+    if (hookResponse.status() === 409) {
+      test.skip(true, "Command queue is full on the target module.");
+    }
+    expect(hookResponse.ok(), `/hook/ returned ${hookResponse.status()}`).toBeTruthy();
+    await expect(hookResponse.text()).resolves.toContain(`19 1 ${xtime}`);
+    await waitForEspToSettle();
+
+    try {
+      const queue = await postJson(request, "/getcommands/");
+      const index = findCommandIndex(
+        queue,
+        (item) =>
+          item.cmd === 19 &&
+          item.value === 1 &&
+          item.xtime === xtime &&
+          item.text === uniqueText,
+      );
+      expect(index, "webhook-created text command should be present").toBeGreaterThanOrEqual(0);
+
+      const deleteResponse = await request.post("/delcommand/", {
+        data: { IDX: index },
+      });
+      expect(deleteResponse.ok(), `/delcommand/ returned ${deleteResponse.status()}`).toBeTruthy();
+      activeText = "";
+      await waitForEspToSettle();
+
+      const queueAfterDelete = await postJson(request, "/getcommands/");
+      expect(
+        findCommandIndex(
+          queueAfterDelete,
+          (item) => item.cmd === 19 && item.xtime === xtime && item.text === uniqueText,
+        ),
+      ).toBe(-1);
+    } finally {
+      if (activeText) {
+        const queue = await postJson(request, "/getcommands/");
+        const index = findCommandIndex(
+          queue,
+          (item) => item.cmd === 19 && item.xtime === xtime && item.text === activeText,
+        );
+        if (index >= 0) {
+          await request.post("/delcommand/", { data: { IDX: index } });
+          await waitForEspToSettle();
+        }
+      }
+    }
+  });
+
+  test("sendcommand fallback can schedule and clean up a safe future text command", async ({ request }) => {
+    const uniqueText = `sc${Date.now().toString(36).slice(-8)}`;
+    let activeText = uniqueText;
+    const xtime = futureTimestamp(10 * 24 * 60 * 60);
+
+    const responseText = await sendCommand(request, {
+      CMD: 19,
+      VALUE: 1,
+      XTIME: xtime,
+      INTERVAL: 0,
+      TXT: uniqueText,
+    });
+    expect(responseText).toContain(`19 1 ${xtime}`);
+
+    try {
+      const queue = await postJson(request, "/getcommands/");
+      const index = findCommandIndex(
+        queue,
+        (item) =>
+          item.cmd === 19 &&
+          item.value === 1 &&
+          item.xtime === xtime &&
+          item.text === uniqueText,
+      );
+      expect(index, "sendcommand-created text command should be present").toBeGreaterThanOrEqual(0);
+
+      const deleteResponse = await request.post("/delcommand/", {
+        data: { IDX: index },
+      });
+      expect(deleteResponse.ok(), `/delcommand/ returned ${deleteResponse.status()}`).toBeTruthy();
+      activeText = "";
+      await waitForEspToSettle();
+    } finally {
+      if (activeText) {
+        const queue = await postJson(request, "/getcommands/");
+        const index = findCommandIndex(
+          queue,
+          (item) => item.cmd === 19 && item.xtime === xtime && item.text === activeText,
+        );
+        if (index >= 0) {
+          await request.post("/delcommand/", { data: { IDX: index } });
+          await waitForEspToSettle();
+        }
+      }
+    }
+  });
+
+  test("command queue can download and rejects invalid restore payload", async ({ request }) => {
+    const downloaded = await postJson(request, "/cmdq_file/", { ACT: "download" });
+    expect(downloaded).toEqual(expect.any(Object));
+
+    const invalidUpload = await request.post("/cmdq_file/?action=upload", {
+      headers: { "Content-Type": "application/json" },
+      data: "not-json",
+    });
+    expect(invalidUpload.status()).toBe(400);
+    await expect(invalidUpload.text()).resolves.toMatch(
+      /Ungültiges JSON-Format|Datei muss ein JSON-Objekt enthalten/,
+    );
+    await waitForEspToSettle();
+  });
+
+  test("command queue restore rejects malformed structures", async ({ request }) => {
+    const invalidPayloads = [
+      {
+        name: "missing LEN",
+        payload: { CMD: [19], VALUE: [1], XTIME: [futureTimestamp()], INTERVAL: [0], TXT: ["bad"] },
+        expected: "Datei fehlt erforderliche Felder",
+      },
+      {
+        name: "array length mismatch",
+        payload: { LEN: 2, CMD: [19], VALUE: [1, 1], XTIME: [futureTimestamp(), futureTimestamp()], INTERVAL: [0, 0], TXT: ["bad", "bad2"] },
+        expected: "Array-Längen stimmen nicht mit LEN überein",
+      },
+      {
+        name: "too many commands",
+        payload: {
+          LEN: 21,
+          CMD: Array(21).fill(19),
+          VALUE: Array(21).fill(1),
+          XTIME: Array(21).fill(futureTimestamp()),
+          INTERVAL: Array(21).fill(0),
+          TXT: Array(21).fill("bad"),
+        },
+        expected: "Warteschlange enthält zu viele Befehle",
+      },
+      {
+        name: "invalid TXT shape",
+        payload: { LEN: 1, CMD: [19], VALUE: [1], XTIME: [futureTimestamp()], INTERVAL: [0], TXT: "bad" },
+        expected: "TXT muss ein Array sein",
+      },
+    ];
+
+    for (const item of invalidPayloads) {
+      const response = await request.post("/cmdq_file/?action=upload", {
+        headers: { "Content-Type": "application/json" },
+        data: JSON.stringify(item.payload),
+      });
+      expect(response.status(), `${item.name} should be rejected`).toBe(400);
+      await expect(response.text()).resolves.toContain(item.expected);
+      await waitForEspToSettle();
+    }
+  });
+
+  test("smart schedule API rejects invalid updates without creating schedules", async ({ request }) => {
+    const pastSchedule = await request.post("/setsmartschedule/", {
+      data: {
+        TARGETTIME: Math.floor(Date.now() / 1000) - 3600,
+        TARGETTEMP: 37,
+        KEEPON: false,
+      },
+    });
+    expect(pastSchedule.status()).toBe(400);
+    await waitForEspToSettle();
+
+    const invalidTemp = await request.post("/setsmartschedule/", {
+      data: {
+        TARGETTIME: futureTimestamp(),
+        TARGETTEMP: 99,
+        KEEPON: false,
+      },
+    });
+    expect(invalidTemp.status()).toBe(400);
+    await waitForEspToSettle();
+
+    const missingKeepOn = await request.post("/updatesmartschedule/", {
+      data: {},
+    });
+    expect(missingKeepOn.status()).toBe(400);
+    await expect(missingKeepOn.text()).resolves.toContain("Missing KEEPON");
+    await waitForEspToSettle();
+  });
+
+  test("target temperature and brightness can be changed and restored", async ({ request }) => {
+    const originalStates = await getPollStates(request);
+    const originalTarget = originalStates.TGT;
+    const originalBrightness = originalStates.BRT;
+    const newTarget = originalStates.UNT
+      ? originalTarget < 40 ? originalTarget + 1 : originalTarget - 1
+      : originalTarget < 104 ? originalTarget + 1 : originalTarget - 1;
+    const newBrightness = originalBrightness === 7 ? 8 : 7;
+    let targetChanged = false;
+    let brightnessChanged = false;
+
+    try {
+      await sendCommand(request, { CMD: 0, VALUE: newTarget });
+      await waitForHardwareCommandToApply();
+      targetChanged = true;
+      const targetResult = await waitForPolledValue(
+        async () => (await getPollStates(request)).TGT,
+        newTarget,
+      );
+      expect(
+        targetResult.matched,
+        `Target temperature command was accepted, but the module still reports ${JSON.stringify(targetResult.lastValue)}.`,
+      ).toBeTruthy();
+
+      await sendCommand(request, { CMD: 12, VALUE: newBrightness });
+      await waitForHardwareCommandToApply();
+      brightnessChanged = true;
+      const brightnessResult = await waitForPolledValue(
+        async () => (await getPollStates(request)).BRT,
+        newBrightness,
+      );
+      expect(
+        brightnessResult.matched,
+        `Brightness command was accepted, but the module still reports ${JSON.stringify(brightnessResult.lastValue)}.`,
+      ).toBeTruthy();
+    } finally {
+      if (targetChanged) {
+        await sendCommand(request, { CMD: 0, VALUE: originalTarget });
+        await waitForHardwareCommandToApply();
+        await expectPolledValue(
+          async () => (await getPollStates(request)).TGT,
+          originalTarget,
+          "target temperature should be restored",
+        );
+      }
+
+      if (brightnessChanged) {
+        await sendCommand(request, { CMD: 12, VALUE: originalBrightness });
+        await waitForHardwareCommandToApply();
+        await expectPolledValue(
+          async () => (await getPollStates(request)).BRT,
+          originalBrightness,
+          "brightness should be restored",
+        );
+      }
+    }
+  });
+
+  test("lock can be toggled and restored", async ({ request }) => {
+    const originalLock = Boolean((await getWebhookStates(request)).lock);
+    let lockChanged = false;
+
+    try {
+      await sendCommand(request, { CMD: 23, VALUE: 1 });
+      await waitForHardwareCommandToApply();
+      lockChanged = true;
+      const lockResult = await waitForPolledValue(
+        async () => Boolean((await getWebhookStates(request)).lock),
+        !originalLock,
+      );
+      expect(
+        lockResult.matched,
+        `Lock command was accepted, but the module still reports ${JSON.stringify(lockResult.lastValue)}.`,
+      ).toBeTruthy();
+    } finally {
+      const currentLock = Boolean((await getWebhookStates(request)).lock);
+      if (currentLock !== originalLock) {
+        await sendCommand(request, { CMD: 23, VALUE: 1 });
+        await waitForHardwareCommandToApply();
+      }
+      if (lockChanged || currentLock !== originalLock) {
+        await expectPolledValue(
+          async () => Boolean((await getWebhookStates(request)).lock),
+          originalLock,
+          "lock should be restored",
+        );
+      }
+    }
+  });
+
+  test("safe future text command can be added, edited, and deleted", async ({ request }) => {
+    const uniqueText = `e2e${Date.now().toString(36).slice(-8)}`;
+    const editedText = `${uniqueText}x`;
+    let activeText = uniqueText;
+
+    const addResponse = await request.post("/addcommand/", {
+      data: {
+        CMD: 19,
+        VALUE: 1,
+        XTIME: futureTimestamp(),
+        INTERVAL: 0,
+        TXT: uniqueText,
+      },
+    });
+
+    if (addResponse.status() === 409) {
+      test.skip(true, "Command queue is full on the target module.");
+    }
+    expect(addResponse.ok(), `/addcommand/ returned ${addResponse.status()}`).toBeTruthy();
+    await waitForEspToSettle();
+
+    try {
+      let queue = await postJson(request, "/getcommands/");
+      let index = findCommandIndex(
+        queue,
+        (item) => item.cmd === 19 && item.text === uniqueText,
+      );
+      expect(index, "added text command should be present").toBeGreaterThanOrEqual(0);
+
+      const editResponse = await request.post("/editcommand/", {
+        data: {
+          IDX: index,
+          CMD: 19,
+          VALUE: 1,
+          XTIME: futureTimestamp(8 * 24 * 60 * 60),
+          INTERVAL: 0,
+          TXT: editedText,
+        },
+      });
+      expect(editResponse.ok(), `/editcommand/ returned ${editResponse.status()}`).toBeTruthy();
+      activeText = editedText;
+      await waitForEspToSettle();
+
+      queue = await postJson(request, "/getcommands/");
+      index = findCommandIndex(
+        queue,
+        (item) => item.cmd === 19 && item.text === editedText,
+      );
+      expect(index, "edited text command should be present").toBeGreaterThanOrEqual(0);
+
+      const deleteResponse = await request.post("/delcommand/", {
+        data: { IDX: index },
+      });
+      expect(deleteResponse.ok(), `/delcommand/ returned ${deleteResponse.status()}`).toBeTruthy();
+      activeText = "";
+      await waitForEspToSettle();
+
+      queue = await postJson(request, "/getcommands/");
+      expect(
+        findCommandIndex(queue, (item) => item.cmd === 19 && item.text === editedText),
+      ).toBe(-1);
+    } finally {
+      if (activeText) {
+        const queue = await postJson(request, "/getcommands/");
+        const index = findCommandIndex(
+          queue,
+          (item) => item.cmd === 19 && item.text === activeText,
+        );
+        if (index >= 0) {
+          await request.post("/delcommand/", { data: { IDX: index } });
+          await waitForEspToSettle();
+        }
+      }
+    }
+  });
+
+  test("dashboard and navigation pages load without unsafe control actions", async ({ page }) => {
+    const pages = [
+      { path: "/", title: "WifiWhirl" },
+      { path: "/config.html", title: "SPA-Konfiguration" },
+      { path: "/automation.html", title: "Automatisierung" },
+      { path: "/smartschedule.html", title: "Smart Schedule" },
+      { path: "/webconfig.html", title: "Web-Konfiguration" },
+      { path: "/wifi.html", title: "Netzwerkkonfiguration" },
+      { path: "/hwconfig.html", title: "Pumpenkonfiguration" },
+      { path: "/info.html", title: "Softwareinfo" },
+    ];
+
+    for (const item of pages) {
+      await page.goto(item.path, { waitUntil: "domcontentloaded" });
+      await expect(page.locator("#site")).toBeVisible();
+      await expect(page.locator("#header")).toContainText(item.title);
+    }
+  });
+
+  test("smart schedule exposes cost estimate and editable heater target behavior", async ({ page }) => {
+    await page.goto("/smartschedule.html", { waitUntil: "domcontentloaded" });
+
+    await expect(page.locator("#statusCost")).toBeAttached();
+    await expect(page.locator("#activeKeepHeaterOn")).toBeAttached();
+    await expect(page.locator("#keepHeaterOn")).toBeVisible();
+
+    await expect(page.locator("#keepHeaterOn option")).toHaveText([
+      "Heizung ausschalten",
+      "Heizung eingeschaltet lassen",
+    ]);
+  });
+
+  test("smart schedule client-side validation blocks unsafe submissions", async ({ page }) => {
+    await page.goto("/smartschedule.html", { waitUntil: "domcontentloaded" });
+
+    await page.locator("#targetDateTime").fill("");
+    await expectAlertFromEvaluate(
+      page,
+      () => window.setSchedule(),
+      "Datum und Uhrzeit",
+    );
+
+    await page.locator("#targetDateTime").fill("2099-01-01T19:00");
+    await page.locator("#targetTemp").fill("99");
+    await expectAlertFromEvaluate(
+      page,
+      () => window.setSchedule(),
+      "zwischen 20°C und 40°C",
+    );
+
+    await page.locator("#targetDateTime").fill("2000-01-01T19:00");
+    await page.locator("#targetTemp").fill("37");
+    await expectAlertFromEvaluate(
+      page,
+      () => window.setSchedule(),
+      "Zielzeit muss in der Zukunft",
+    );
+  });
+
+  test("automation UI uses the safe Bedientasten sperren wording", async ({ page }) => {
+    await page.goto("/automation.html", { waitUntil: "domcontentloaded" });
+
+    const commandSelect = page.locator("#commands");
+    await expect(commandSelect).toBeVisible();
+    await expect(commandSelect.locator('option[value="26"]')).toHaveText(
+      "Bedientasten sperren",
+    );
+
+    await commandSelect.selectOption("26");
+    await expect(page.locator("#vallabel")).toHaveText("Bedientasten:");
+    await expect(page.locator("#onoffinfo")).toHaveText("sperren");
+    await expect(page.locator("#offinfo")).toHaveText("entsperren");
+  });
+
+  test("automation form serializes safe commands without hardware command IDs", async ({ page }) => {
+    await page.goto("/automation.html", { waitUntil: "domcontentloaded" });
+
+    await page.locator("#commands").selectOption("26");
+    const lockButtonsPayload = await page.evaluate(() => window.getCommandJson());
+    expect(lockButtonsPayload).toEqual(
+      expect.objectContaining({
+        CMD: 26,
+        VALUE: 0,
+      }),
+    );
+
+    await page.locator("#valoff").check();
+    const unlockButtonsPayload = await page.evaluate(() => window.getCommandJson());
+    expect(unlockButtonsPayload).toEqual(
+      expect.objectContaining({
+        CMD: 26,
+        VALUE: 1,
+      }),
+    );
+
+    await page.locator("#commands").selectOption("19");
+    await page.locator("#txt").fill("e2etest");
+    const textPayload = await page.evaluate(() => window.getCommandJson());
+    expect(textPayload).toEqual(
+      expect.objectContaining({
+        CMD: 19,
+        TXT: "e2etest",
+      }),
+    );
+  });
+
+  test("dark mode toggle persists locally without module writes", async ({ page }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    const toggle = page.locator("#darkModeToggle");
+    await expect(toggle).toBeAttached();
+    await toggle.evaluate((el) => el.click());
+    await expect(page.locator("html")).toHaveClass(/darkmode/);
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(page.locator("html")).toHaveClass(/darkmode/);
+
+    await page.locator("#darkModeToggle").evaluate((el) => el.click());
+    await expect(page.locator("html")).not.toHaveClass(/darkmode/);
+  });
+
+  test("web config localStorage controls dashboard section visibility without module writes", async ({ page }) => {
+    await page.route("**/getwebconfig/", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          SST: false,
+          SSD: true,
+          SSC: true,
+          SSB: true,
+          SSTIM: true,
+          SSTOT: true,
+          SSEN: true,
+          SSWQ: true,
+          SWQCYA: false,
+          SWQALK: false,
+          UCS: true,
+        }),
+      });
+    });
+    await page.route("**/setwebconfig/", async (route) => {
+      await route.fulfill({ status: 200, contentType: "text/plain", body: "" });
+    });
+
+    await page.goto("/webconfig.html", { waitUntil: "domcontentloaded" });
+    await page.locator("#showSectionTemperature").setChecked(false);
+    await page.evaluate(() => window.saveWebConfig());
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("showSectionTemperature")))
+      .toBe("false");
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("#sectionTemperature")).toBeHidden();
+
+    await page.evaluate(() => {
+      localStorage.removeItem("showSectionTemperature");
+    });
+  });
+
+  test("mobile navigation menu opens and closes", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    const nav = page.locator("#topnav");
+    await expect(nav).toHaveClass("topnav");
+
+    await page.locator(".topnavicon").click();
+    await expect(nav).toHaveClass(/responsive/);
+
+    await page.locator(".topnavicon").click();
+    await expect(nav).toHaveClass("topnav");
+  });
+
+  test("core pages do not overflow on desktop or mobile viewports", async ({ page }) => {
+    const pages = ["/", "/config.html", "/automation.html", "/smartschedule.html", "/webconfig.html", "/wifi.html"];
+    const viewports = [
+      { width: 390, height: 844 },
+      { width: 1280, height: 900 },
+    ];
+
+    for (const viewport of viewports) {
+      await page.setViewportSize(viewport);
+      for (const path of pages) {
+        await page.goto(path, { waitUntil: "domcontentloaded" });
+        const overflow = await page.evaluate(() => {
+          const root = document.documentElement;
+          return root.scrollWidth - root.clientWidth;
+        });
+        expect(overflow, `${path} overflows at ${viewport.width}px`).toBeLessThanOrEqual(2);
+      }
+    }
+  });
+
+  test("static assets and manifest are served", async ({ request }) => {
+    const manifest = await request.get("/manifest.json");
+    expect(manifest.ok(), `/manifest.json returned ${manifest.status()}`).toBeTruthy();
+    const manifestBody = await manifest.json();
+    expect(manifestBody).toEqual(
+      expect.objectContaining({
+        name: expect.any(String),
+      }),
+    );
+
+    for (const asset of ["/main.css", "/function.js", "/logo.png"]) {
+      const response = await request.get(asset);
+      expect(response.ok(), `${asset} returned ${response.status()}`).toBeTruthy();
+      expect(Number(response.headers()["content-length"] || 1)).toBeGreaterThan(0);
+    }
+  });
+
+  test("system info assets and prometheus metrics are served", async ({ request }) => {
+    const infoPage = await request.get("/info.html");
+    expect(infoPage.ok(), `/info.html returned ${infoPage.status()}`).toBeTruthy();
+    await expect(infoPage.text()).resolves.toContain("Softwareinfo");
+
+    for (const asset of ["/favicon.ico", "/Roboto-Regular.woff", "/Roboto-Regular.eot", "/furelise.mel", "/popcorn.mel"]) {
+      const response = await request.get(asset);
+      expect(response.ok(), `${asset} returned ${response.status()}`).toBeTruthy();
+      expect(Number(response.headers()["content-length"] || 1)).toBeGreaterThan(0);
+    }
+
+    const metrics = await request.get("/metrics");
+    expect(metrics.ok(), `/metrics returned ${metrics.status()}`).toBeTruthy();
+    const metricsText = await metrics.text();
+    expect(metricsText).toContain("# HELP");
+    expect(metricsText).toContain("_info");
+    expect(metricsText).toContain("_temperature_celcius");
+  });
+
+  test("configuration pages use alternating section styling", async ({ page }) => {
+    const pages = [
+      "/config.html",
+      "/automation.html",
+      "/smartschedule.html",
+      "/webconfig.html",
+      "/wifi.html",
+      "/hwconfig.html",
+    ];
+
+    for (const path of pages) {
+      await page.goto(path, { waitUntil: "domcontentloaded" });
+      await expect(page.locator("section.odd-section").first()).toBeVisible();
+    }
+  });
+});

--- a/Code/e2e/tests/read-only.spec.js
+++ b/Code/e2e/tests/read-only.spec.js
@@ -98,6 +98,11 @@ async function getWebhookStates(request) {
   return getJsonWithRetry(request, "/getstates/");
 }
 
+async function setConfig(request, config) {
+  const response = await request.post("/setconfig/", { data: config });
+  expect(response.ok(), `/setconfig/ returned ${response.status()}`).toBeTruthy();
+}
+
 async function waitForPolledValue(getter, expected, options = {}) {
   const timeout = options.timeout || 90 * 1000;
   const intervals = options.intervals || [3000, 5000, 7000];
@@ -142,6 +147,7 @@ async function expectAlertFromEvaluate(page, callback, expectedText) {
 }
 
 test.describe("WifiWhirl real module smoke tests", () => {
+  // Read-only status, config, and diagnostics endpoints
   test("read-only backend endpoints respond with expected shapes", async ({ request }) => {
     const statesResponse = await request.get("/gettemps/");
     expect(
@@ -281,6 +287,52 @@ test.describe("WifiWhirl real module smoke tests", () => {
     );
   });
 
+  test("info endpoint reports ESP diagnostics", async ({ request }) => {
+    const response = await request.post("/info/");
+    expect(response.ok(), `/info/ returned ${response.status()}`).toBeTruthy();
+    const body = await response.text();
+    expect(body).toContain("Stack size:");
+    expect(body).toContain("Free Heap:");
+    await waitForEspToSettle();
+  });
+
+  test("static assets and manifest are served", async ({ request }) => {
+    const manifest = await request.get("/manifest.json");
+    expect(manifest.ok(), `/manifest.json returned ${manifest.status()}`).toBeTruthy();
+    const manifestBody = await manifest.json();
+    expect(manifestBody).toEqual(
+      expect.objectContaining({
+        name: expect.any(String),
+      }),
+    );
+
+    for (const asset of ["/main.css", "/function.js", "/logo.png"]) {
+      const response = await request.get(asset);
+      expect(response.ok(), `${asset} returned ${response.status()}`).toBeTruthy();
+      expect(Number(response.headers()["content-length"] || 1)).toBeGreaterThan(0);
+    }
+  });
+
+  test("system info assets and prometheus metrics are served", async ({ request }) => {
+    const infoPage = await request.get("/info.html");
+    expect(infoPage.ok(), `/info.html returned ${infoPage.status()}`).toBeTruthy();
+    await expect(infoPage.text()).resolves.toContain("Softwareinfo");
+
+    for (const asset of ["/favicon.ico", "/Roboto-Regular.woff", "/Roboto-Regular.eot", "/furelise.mel", "/popcorn.mel"]) {
+      const response = await request.get(asset);
+      expect(response.ok(), `${asset} returned ${response.status()}`).toBeTruthy();
+      expect(Number(response.headers()["content-length"] || 1)).toBeGreaterThan(0);
+    }
+
+    const metrics = await request.get("/metrics");
+    expect(metrics.ok(), `/metrics returned ${metrics.status()}`).toBeTruthy();
+    const metricsText = await metrics.text();
+    expect(metricsText).toContain("# HELP");
+    expect(metricsText).toContain("_info");
+    expect(metricsText).toContain("_temperature_celcius");
+  });
+
+  // Webhook and command-queue API
   test("webhook endpoints enforce GET and reject invalid hook payloads", async ({ request }) => {
     for (const path of ["/hook/", "/getstates/", "/gettemps/"]) {
       const response = await request.post(path, { data: {} });
@@ -409,6 +461,82 @@ test.describe("WifiWhirl real module smoke tests", () => {
     }
   });
 
+  test("safe future text command can be added, edited, and deleted", async ({ request }) => {
+    const uniqueText = `e2e${Date.now().toString(36).slice(-8)}`;
+    const editedText = `${uniqueText}x`;
+    let activeText = uniqueText;
+
+    const addResponse = await request.post("/addcommand/", {
+      data: {
+        CMD: 19,
+        VALUE: 1,
+        XTIME: futureTimestamp(),
+        INTERVAL: 0,
+        TXT: uniqueText,
+      },
+    });
+
+    if (addResponse.status() === 409) {
+      test.skip(true, "Command queue is full on the target module.");
+    }
+    expect(addResponse.ok(), `/addcommand/ returned ${addResponse.status()}`).toBeTruthy();
+    await waitForEspToSettle();
+
+    try {
+      let queue = await postJson(request, "/getcommands/");
+      let index = findCommandIndex(
+        queue,
+        (item) => item.cmd === 19 && item.text === uniqueText,
+      );
+      expect(index, "added text command should be present").toBeGreaterThanOrEqual(0);
+
+      const editResponse = await request.post("/editcommand/", {
+        data: {
+          IDX: index,
+          CMD: 19,
+          VALUE: 1,
+          XTIME: futureTimestamp(8 * 24 * 60 * 60),
+          INTERVAL: 0,
+          TXT: editedText,
+        },
+      });
+      expect(editResponse.ok(), `/editcommand/ returned ${editResponse.status()}`).toBeTruthy();
+      activeText = editedText;
+      await waitForEspToSettle();
+
+      queue = await postJson(request, "/getcommands/");
+      index = findCommandIndex(
+        queue,
+        (item) => item.cmd === 19 && item.text === editedText,
+      );
+      expect(index, "edited text command should be present").toBeGreaterThanOrEqual(0);
+
+      const deleteResponse = await request.post("/delcommand/", {
+        data: { IDX: index },
+      });
+      expect(deleteResponse.ok(), `/delcommand/ returned ${deleteResponse.status()}`).toBeTruthy();
+      activeText = "";
+      await waitForEspToSettle();
+
+      queue = await postJson(request, "/getcommands/");
+      expect(
+        findCommandIndex(queue, (item) => item.cmd === 19 && item.text === editedText),
+      ).toBe(-1);
+    } finally {
+      if (activeText) {
+        const queue = await postJson(request, "/getcommands/");
+        const index = findCommandIndex(
+          queue,
+          (item) => item.cmd === 19 && item.text === activeText,
+        );
+        if (index >= 0) {
+          await request.post("/delcommand/", { data: { IDX: index } });
+          await waitForEspToSettle();
+        }
+      }
+    }
+  });
+
   test("command queue can download and rejects invalid restore payload", async ({ request }) => {
     const downloaded = await postJson(request, "/cmdq_file/", { ACT: "download" });
     expect(downloaded).toEqual(expect.any(Object));
@@ -466,6 +594,7 @@ test.describe("WifiWhirl real module smoke tests", () => {
     }
   });
 
+  // Smart schedule API and UI
   test("smart schedule API rejects invalid updates without creating schedules", async ({ request }) => {
     const pastSchedule = await request.post("/setsmartschedule/", {
       data: {
@@ -495,6 +624,89 @@ test.describe("WifiWhirl real module smoke tests", () => {
     await waitForEspToSettle();
   });
 
+  test("smart schedule can be created, verified, and cancelled", async ({ request }) => {
+    const existing = await postJson(request, "/getsmartschedule/");
+    if (existing.ACTIVE) {
+      await request.post("/cancelsmartschedule/");
+      await waitForEspToSettle();
+    }
+
+    const targetTime = futureTimestamp();
+    const targetTemp = 37;
+    let scheduleActive = false;
+
+    try {
+      const setResponse = await request.post("/setsmartschedule/", {
+        data: { TARGETTIME: targetTime, TARGETTEMP: targetTemp, KEEPON: false },
+      });
+      expect(setResponse.ok(), `/setsmartschedule/ returned ${setResponse.status()}`).toBeTruthy();
+      await expect(setResponse.text()).resolves.toContain("Schedule set successfully");
+      scheduleActive = true;
+      await waitForEspToSettle();
+
+      const schedule = await postJson(request, "/getsmartschedule/");
+      expect(schedule).toEqual(
+        expect.objectContaining({
+          ACTIVE: true,
+          TARGETTIME: targetTime,
+          TARGETTEMP: targetTemp,
+          KEEPON: false,
+        }),
+      );
+    } finally {
+      if (scheduleActive) {
+        const cancelResponse = await request.post("/cancelsmartschedule/");
+        expect(cancelResponse.ok(), `/cancelsmartschedule/ returned ${cancelResponse.status()}`).toBeTruthy();
+        await expect(cancelResponse.text()).resolves.toContain("Schedule cancelled");
+        await waitForEspToSettle();
+
+        const scheduleAfterCancel = await postJson(request, "/getsmartschedule/");
+        expect(scheduleAfterCancel.ACTIVE).toBe(false);
+      }
+    }
+  });
+
+  test("smart schedule exposes cost estimate and editable heater target behavior", async ({ page }) => {
+    await page.goto("/smartschedule.html", { waitUntil: "domcontentloaded" });
+
+    await expect(page.locator("#statusCost")).toBeAttached();
+    await expect(page.locator("#activeKeepHeaterOn")).toBeAttached();
+    await expect(page.locator("#keepHeaterOn")).toBeVisible();
+
+    await expect(page.locator("#keepHeaterOn option")).toHaveText([
+      "Heizung ausschalten",
+      "Heizung eingeschaltet lassen",
+    ]);
+  });
+
+  test("smart schedule client-side validation blocks unsafe submissions", async ({ page }) => {
+    await page.goto("/smartschedule.html", { waitUntil: "domcontentloaded" });
+
+    await page.locator("#targetDateTime").fill("");
+    await expectAlertFromEvaluate(
+      page,
+      () => window.setSchedule(),
+      "Datum und Uhrzeit",
+    );
+
+    await page.locator("#targetDateTime").fill("2099-01-01T19:00");
+    await page.locator("#targetTemp").fill("99");
+    await expectAlertFromEvaluate(
+      page,
+      () => window.setSchedule(),
+      "zwischen 20°C und 40°C",
+    );
+
+    await page.locator("#targetDateTime").fill("2000-01-01T19:00");
+    await page.locator("#targetTemp").fill("37");
+    await expectAlertFromEvaluate(
+      page,
+      () => window.setSchedule(),
+      "Zielzeit muss in der Zukunft",
+    );
+  });
+
+  // Hardware-facing state changes (target temp, brightness, lock)
   test("target temperature and brightness can be changed and restored", async ({ request }) => {
     const originalStates = await getPollStates(request);
     const originalTarget = originalStates.TGT;
@@ -585,82 +797,55 @@ test.describe("WifiWhirl real module smoke tests", () => {
     }
   });
 
-  test("safe future text command can be added, edited, and deleted", async ({ request }) => {
-    const uniqueText = `e2e${Date.now().toString(36).slice(-8)}`;
-    const editedText = `${uniqueText}x`;
-    let activeText = uniqueText;
-
-    const addResponse = await request.post("/addcommand/", {
-      data: {
-        CMD: 19,
-        VALUE: 1,
-        XTIME: futureTimestamp(),
-        INTERVAL: 0,
-        TXT: uniqueText,
-      },
-    });
-
-    if (addResponse.status() === 409) {
-      test.skip(true, "Command queue is full on the target module.");
-    }
-    expect(addResponse.ok(), `/addcommand/ returned ${addResponse.status()}`).toBeTruthy();
-    await waitForEspToSettle();
+  // Settings (/getconfig//setconfig/) round trips
+  test("configurable timezone can be changed and restored", async ({ request }) => {
+    const originalConfig = await postJson(request, "/getconfig/");
+    const newTimezone = { TIMEZONE: "UTC0", TIMEZONE_NAME: "UTC" };
 
     try {
-      let queue = await postJson(request, "/getcommands/");
-      let index = findCommandIndex(
-        queue,
-        (item) => item.cmd === 19 && item.text === uniqueText,
-      );
-      expect(index, "added text command should be present").toBeGreaterThanOrEqual(0);
-
-      const editResponse = await request.post("/editcommand/", {
-        data: {
-          IDX: index,
-          CMD: 19,
-          VALUE: 1,
-          XTIME: futureTimestamp(8 * 24 * 60 * 60),
-          INTERVAL: 0,
-          TXT: editedText,
-        },
-      });
-      expect(editResponse.ok(), `/editcommand/ returned ${editResponse.status()}`).toBeTruthy();
-      activeText = editedText;
+      await setConfig(request, { ...originalConfig, ...newTimezone });
       await waitForEspToSettle();
 
-      queue = await postJson(request, "/getcommands/");
-      index = findCommandIndex(
-        queue,
-        (item) => item.cmd === 19 && item.text === editedText,
-      );
-      expect(index, "edited text command should be present").toBeGreaterThanOrEqual(0);
-
-      const deleteResponse = await request.post("/delcommand/", {
-        data: { IDX: index },
-      });
-      expect(deleteResponse.ok(), `/delcommand/ returned ${deleteResponse.status()}`).toBeTruthy();
-      activeText = "";
-      await waitForEspToSettle();
-
-      queue = await postJson(request, "/getcommands/");
-      expect(
-        findCommandIndex(queue, (item) => item.cmd === 19 && item.text === editedText),
-      ).toBe(-1);
+      const updatedConfig = await postJson(request, "/getconfig/");
+      expect(updatedConfig).toEqual(expect.objectContaining(newTimezone));
     } finally {
-      if (activeText) {
-        const queue = await postJson(request, "/getcommands/");
-        const index = findCommandIndex(
-          queue,
-          (item) => item.cmd === 19 && item.text === activeText,
-        );
-        if (index >= 0) {
-          await request.post("/delcommand/", { data: { IDX: index } });
-          await waitForEspToSettle();
-        }
-      }
+      await setConfig(request, originalConfig);
+      await waitForEspToSettle();
+
+      const restoredConfig = await postJson(request, "/getconfig/");
+      expect(restoredConfig).toEqual(
+        expect.objectContaining({
+          TIMEZONE: originalConfig.TIMEZONE,
+          TIMEZONE_NAME: originalConfig.TIMEZONE_NAME,
+        }),
+      );
     }
   });
 
+  test("weather endpoint returns the city name for German and Austrian PLZ", async ({ request }) => {
+    const originalConfig = await postJson(request, "/getconfig/");
+    const plzCodes = ["48268", "1010"];
+
+    try {
+      for (const plz of plzCodes) {
+        await setConfig(request, { ...originalConfig, PLZ: plz });
+        await waitForEspToSettle();
+
+        const weatherResponse = await request.get("/getweather/");
+        expect(
+          weatherResponse.ok(),
+          `/getweather/ for PLZ ${plz} returned ${weatherResponse.status()}`,
+        ).toBeTruthy();
+        const cityName = await weatherResponse.text();
+        expect(cityName.trim().length, `/getweather/ for PLZ ${plz} returned no city name`).toBeGreaterThan(0);
+      }
+    } finally {
+      await setConfig(request, originalConfig);
+      await waitForEspToSettle();
+    }
+  });
+
+  // Pages and frontend UI behavior
   test("dashboard and navigation pages load without unsafe control actions", async ({ page }) => {
     const pages = [
       { path: "/", title: "WifiWhirl" },
@@ -680,44 +865,20 @@ test.describe("WifiWhirl real module smoke tests", () => {
     }
   });
 
-  test("smart schedule exposes cost estimate and editable heater target behavior", async ({ page }) => {
-    await page.goto("/smartschedule.html", { waitUntil: "domcontentloaded" });
+  test("configuration pages use alternating section styling", async ({ page }) => {
+    const pages = [
+      "/config.html",
+      "/automation.html",
+      "/smartschedule.html",
+      "/webconfig.html",
+      "/wifi.html",
+      "/hwconfig.html",
+    ];
 
-    await expect(page.locator("#statusCost")).toBeAttached();
-    await expect(page.locator("#activeKeepHeaterOn")).toBeAttached();
-    await expect(page.locator("#keepHeaterOn")).toBeVisible();
-
-    await expect(page.locator("#keepHeaterOn option")).toHaveText([
-      "Heizung ausschalten",
-      "Heizung eingeschaltet lassen",
-    ]);
-  });
-
-  test("smart schedule client-side validation blocks unsafe submissions", async ({ page }) => {
-    await page.goto("/smartschedule.html", { waitUntil: "domcontentloaded" });
-
-    await page.locator("#targetDateTime").fill("");
-    await expectAlertFromEvaluate(
-      page,
-      () => window.setSchedule(),
-      "Datum und Uhrzeit",
-    );
-
-    await page.locator("#targetDateTime").fill("2099-01-01T19:00");
-    await page.locator("#targetTemp").fill("99");
-    await expectAlertFromEvaluate(
-      page,
-      () => window.setSchedule(),
-      "zwischen 20°C und 40°C",
-    );
-
-    await page.locator("#targetDateTime").fill("2000-01-01T19:00");
-    await page.locator("#targetTemp").fill("37");
-    await expectAlertFromEvaluate(
-      page,
-      () => window.setSchedule(),
-      "Zielzeit muss in der Zukunft",
-    );
+    for (const path of pages) {
+      await page.goto(path, { waitUntil: "domcontentloaded" });
+      await expect(page.locator("section.odd-section").first()).toBeVisible();
+    }
   });
 
   test("automation UI uses the safe Bedientasten sperren wording", async ({ page }) => {
@@ -852,58 +1013,6 @@ test.describe("WifiWhirl real module smoke tests", () => {
         });
         expect(overflow, `${path} overflows at ${viewport.width}px`).toBeLessThanOrEqual(2);
       }
-    }
-  });
-
-  test("static assets and manifest are served", async ({ request }) => {
-    const manifest = await request.get("/manifest.json");
-    expect(manifest.ok(), `/manifest.json returned ${manifest.status()}`).toBeTruthy();
-    const manifestBody = await manifest.json();
-    expect(manifestBody).toEqual(
-      expect.objectContaining({
-        name: expect.any(String),
-      }),
-    );
-
-    for (const asset of ["/main.css", "/function.js", "/logo.png"]) {
-      const response = await request.get(asset);
-      expect(response.ok(), `${asset} returned ${response.status()}`).toBeTruthy();
-      expect(Number(response.headers()["content-length"] || 1)).toBeGreaterThan(0);
-    }
-  });
-
-  test("system info assets and prometheus metrics are served", async ({ request }) => {
-    const infoPage = await request.get("/info.html");
-    expect(infoPage.ok(), `/info.html returned ${infoPage.status()}`).toBeTruthy();
-    await expect(infoPage.text()).resolves.toContain("Softwareinfo");
-
-    for (const asset of ["/favicon.ico", "/Roboto-Regular.woff", "/Roboto-Regular.eot", "/furelise.mel", "/popcorn.mel"]) {
-      const response = await request.get(asset);
-      expect(response.ok(), `${asset} returned ${response.status()}`).toBeTruthy();
-      expect(Number(response.headers()["content-length"] || 1)).toBeGreaterThan(0);
-    }
-
-    const metrics = await request.get("/metrics");
-    expect(metrics.ok(), `/metrics returned ${metrics.status()}`).toBeTruthy();
-    const metricsText = await metrics.text();
-    expect(metricsText).toContain("# HELP");
-    expect(metricsText).toContain("_info");
-    expect(metricsText).toContain("_temperature_celcius");
-  });
-
-  test("configuration pages use alternating section styling", async ({ page }) => {
-    const pages = [
-      "/config.html",
-      "/automation.html",
-      "/smartschedule.html",
-      "/webconfig.html",
-      "/wifi.html",
-      "/hwconfig.html",
-    ];
-
-    for (const path of pages) {
-      await page.goto(path, { waitUntil: "domcontentloaded" });
-      await expect(page.locator("section.odd-section").first()).toBeVisible();
     }
   });
 });


### PR DESCRIPTION
Add a Docker-backed Playwright end-to-end test suite that runs against a
live WifiWhirl module on the local network. This is additive test
infrastructure only; no firmware or application code changes.

Included commits:
  86b3977 feat(e2e): add Playwright tests for real WifiWhirl modules
  2a48ca3 feat(e2e): expand real-module coverage for schedule, config, and weather

Test coverage:
  - Read-only backend APIs (status, config, temperature, polling, webhooks, /info/)
  - Static assets, Prometheus metrics, and webhook validation
  - Safe temporary writes with automatic restore (target temp, brightness, lock,
    timezone, future PRINTTEXT, Smart Schedule create/cancel)
  - Command queue download/restore validation
  - Smart Schedule API, UI validation, and cost-estimate behavior
  - Weather endpoint for DE/AT PLZ codes
  - UI navigation, dark mode, localStorage, mobile menu, viewport overflow checks

Safety:
  - Pump, heater, and jet controls are intentionally excluded
  - Smart Schedule tests may start pump/heater as normal device behavior;
    README documents dry-run E02 risk and descaler cartridge guidance

Run via Docker:
  docker build -t wifiwhirl-e2e Code/e2e
  docker run --rm -e MODULE_URL=http://<module-ip> wifiwhirl-e2e